### PR TITLE
Add result type for use in completion handler

### DIFF
--- a/HikeOregon/HikeOregon.xcodeproj/project.pbxproj
+++ b/HikeOregon/HikeOregon.xcodeproj/project.pbxproj
@@ -39,6 +39,11 @@
 		0835FADC1E58F9EF0029D9F0 /* GenericRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0835FADB1E58F9EF0029D9F0 /* GenericRequestTests.swift */; };
 		0835FADE1E5932BD0029D9F0 /* TrailResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0835FADD1E5932BD0029D9F0 /* TrailResponseTests.swift */; };
 		0835FAE01E5933CE0029D9F0 /* GenericResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0835FADF1E5933CE0029D9F0 /* GenericResponseTests.swift */; };
+		0835FAE21E5A008B0029D9F0 /* ParameterMockObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0835FAE11E5A008B0029D9F0 /* ParameterMockObjects.swift */; };
+		0835FAE71E5A01460029D9F0 /* GenericParameterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0835FAE61E5A01460029D9F0 /* GenericParameterTests.swift */; };
+		0835FAE91E5A23CE0029D9F0 /* Sequence+HikeOregon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0835FAE81E5A23CE0029D9F0 /* Sequence+HikeOregon.swift */; };
+		08731E6A1E6611C7005D9257 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08731E691E6611C7005D9257 /* Result.swift */; };
+		08731E6D1E661A10005D9257 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08731E6C1E661A10005D9257 /* ResultTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +102,11 @@
 		0835FADB1E58F9EF0029D9F0 /* GenericRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GenericRequestTests.swift; path = Requests/GenericRequestTests.swift; sourceTree = "<group>"; };
 		0835FADD1E5932BD0029D9F0 /* TrailResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TrailResponseTests.swift; path = Responses/TrailResponseTests.swift; sourceTree = "<group>"; };
 		0835FADF1E5933CE0029D9F0 /* GenericResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GenericResponseTests.swift; path = Responses/GenericResponseTests.swift; sourceTree = "<group>"; };
+		0835FAE11E5A008B0029D9F0 /* ParameterMockObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ParameterMockObjects.swift; path = Mocks/ParameterMockObjects.swift; sourceTree = "<group>"; };
+		0835FAE61E5A01460029D9F0 /* GenericParameterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GenericParameterTests.swift; path = Requests/GenericParameterTests.swift; sourceTree = "<group>"; };
+		0835FAE81E5A23CE0029D9F0 /* Sequence+HikeOregon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Sequence+HikeOregon.swift"; path = "Extensions/Sequence+HikeOregon.swift"; sourceTree = "<group>"; };
+		08731E691E6611C7005D9257 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Result.swift; path = Utilities/Result.swift; sourceTree = "<group>"; };
+		08731E6C1E661A10005D9257 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResultTests.swift; path = Utilities/ResultTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +174,7 @@
 		0835FA7F1E58B30F0029D9F0 /* HikeOregonTests */ = {
 			isa = PBXGroup;
 			children = (
+				08731E6B1E6619F4005D9257 /* Utilities */,
 				0835FAD21E58E98F0029D9F0 /* Responses */,
 				0835FAAD1E58C2140029D9F0 /* Requests */,
 				0835FAA71E58BFFD0029D9F0 /* NetworkMocks */,
@@ -238,6 +249,7 @@
 			isa = PBXGroup;
 			children = (
 				0835FAAB1E58C0D40029D9F0 /* HTTPClient.swift */,
+				08731E691E6611C7005D9257 /* Result.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -326,6 +338,22 @@
 				0835FADF1E5933CE0029D9F0 /* GenericResponseTests.swift */,
 			);
 			name = Responses;
+			sourceTree = "<group>";
+		};
+		0835FAE31E5A00FB0029D9F0 /* Parameters */ = {
+			isa = PBXGroup;
+			children = (
+				0835FAE61E5A01460029D9F0 /* GenericParameterTests.swift */,
+			);
+			name = Parameters;
+			sourceTree = "<group>";
+		};
+		08731E6B1E6619F4005D9257 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				08731E6C1E661A10005D9257 /* ResultTests.swift */,
+			);
+			name = Utilities;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -467,6 +495,7 @@
 			files = (
 				0835FA6E1E58B30E0029D9F0 /* ViewController.swift in Sources */,
 				0835FAC21E58CAFF0029D9F0 /* TrailResponse.swift in Sources */,
+				08731E6A1E6611C7005D9257 /* Result.swift in Sources */,
 				0835FACE1E58E56A0029D9F0 /* Endpoints.swift in Sources */,
 				0835FAAC1E58C0D40029D9F0 /* HTTPClient.swift in Sources */,
 				0835FA9B1E58B34A0029D9F0 /* Trail.swift in Sources */,
@@ -489,6 +518,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08731E6D1E661A10005D9257 /* ResultTests.swift in Sources */,
 				0835FAE01E5933CE0029D9F0 /* GenericResponseTests.swift in Sources */,
 				0835FAD11E58E9440029D9F0 /* Responses.swift in Sources */,
 				0835FA9E1E58B8E10029D9F0 /* TrailModelTests.swift in Sources */,

--- a/HikeOregon/HikeOregon/Utilities/Result.swift
+++ b/HikeOregon/HikeOregon/Utilities/Result.swift
@@ -1,0 +1,118 @@
+//
+//  Result.swift
+//  HikeOregon
+//
+//  Created by Daniel Seitz on 2/28/17.
+//  Copyright © 2017 hikeoregon. All rights reserved.
+//
+
+import Foundation
+
+enum Result<T, E> {
+  case ok(T)
+  case err(E)
+}
+
+extension Result {
+  func isOk() -> Bool {
+    switch self {
+    case .ok(_): return true
+    case .err(_): return false
+    }
+  }
+  
+  func isErr() -> Bool {
+    return !self.isOk()
+  }
+  
+  func intoOk() -> T? {
+    guard case .ok(let val) = self else {
+      return nil
+    }
+    return val
+  }
+  
+  func intoErr() -> E? {
+    guard case .err(let error) = self else {
+      return nil
+    }
+    return error
+  }
+  
+  func map<U>(_ op: (T) -> U) -> Result<U, E> {
+    switch self {
+    case .ok(let val): return .ok(op(val))
+    case .err(let error): return .err(error)
+    }
+  }
+  
+  func mapErr<F>(_ op: (E) -> F) -> Result<T, F> {
+    switch self {
+    case .ok(let val): return .ok(val)
+    case .err(let error): return .err(op(error))
+    }
+  }
+  
+  func and<U>(_ res: Result<U, E>) -> Result<U, E> {
+    guard case .err(let error) = self else {
+      return res
+    }
+    return .err(error)
+  }
+  
+  func andThen<U>(_ op: (T) -> Result<U, E>) -> Result<U, E> {
+    switch self {
+    case .ok(let val): return op(val)
+    case .err(let error): return .err(error)
+    }
+  }
+  
+  func or<F>(_ res: Result<T, F>) -> Result<T, F> {
+    guard case .ok(let val) = self else {
+      return res
+    }
+    return .ok(val)
+  }
+  
+  func orElse<F>(_ op: (E) -> Result<T, F>) -> Result<T, F> {
+    switch self {
+    case .ok(let val): return .ok(val)
+    case .err(let error): return op(error)
+    }
+  }
+  
+  func unwrap(or def: T) -> T {
+    guard case .ok(let val) = self else {
+      return def
+    }
+    return val
+  }
+  
+  func unwrap(orElse handler: (E) -> T) -> T {
+    switch self {
+    case .ok(let val): return val
+    case .err(let error): return handler(error)
+    }
+  }
+  
+  func unwrap() -> T {
+    switch self {
+    case .ok(let val): return val
+    case .err(let error): fatalError("Tried to unwrap result with error: \(error)")
+    }
+  }
+  
+  func expect(message: String) -> T {
+    guard case .ok(let val) = self else {
+      fatalError(message)
+    }
+    return val
+  }
+  
+  func unwrapErr() -> E {
+    switch self {
+    case .ok(let val): fatalError("Tried to unwrap result with value: \(val)")
+    case .err(let error): return error
+    }
+  }
+}

--- a/HikeOregon/HikeOregon/ViewController.swift
+++ b/HikeOregon/HikeOregon/ViewController.swift
@@ -14,22 +14,24 @@ class ViewController: UIViewController {
     super.viewDidLoad()
     
     let trailRequest = TrailRequest(page: nil, searchFor: nil, difficulty: nil, hasRestroom: nil, length: nil)
-    trailRequest.send {(response, error) in
-      if let response = response {
+    trailRequest.send {(result) in
+      print("--------------------")
+      switch result {
+      case .ok(let response):
         print(response.trails)
-      }
-      else {
-        print("RESPONSE NOT PARSED")
+      case .err(let error):
+        print("RESPONSE NOT PARSED: \(error)")
       }
     }
     
     let idRequest = TrailIdRequest(forId: 1)
-    idRequest.send {(response, error) in
-      if let response = response {
+    idRequest.send {(result) in
+      print("--------------------")
+      switch result {
+      case .ok(let response):
         print(response.trails)
-      }
-      else {
-        print("ID RESPONSE NOT PARSED")
+      case .err(let error):
+        print("ID RESPONSE NOT PARSED: \(error)")
       }
     }
   }

--- a/HikeOregon/HikeOregonTests/Requests/GenericRequestTests.swift
+++ b/HikeOregon/HikeOregonTests/Requests/GenericRequestTests.swift
@@ -30,11 +30,9 @@ class GenericRequestTests: XCTestCase, RequestTestable {
   func test_MalformedJson_CallsbackWithParseError() {
     let expect = expectation(description: "handler called")
     self.session.nextData = Data(base64Encoded: ResponseInjections.malformedJson)
-    self.request.send {(response, error) in
-      XCTAssertNil(response)
-      XCTAssertNotNil(error)
-      
-      XCTAssertEqual(error! as! ResponseError, ResponseError.failedToParse)
+    self.request.send {(result) in
+      XCTAssert(result.isErr())
+      XCTAssertEqual(result.intoErr()! as! ResponseError, .failedToParse)
       expect.fulfill()
     }
     
@@ -43,11 +41,9 @@ class GenericRequestTests: XCTestCase, RequestTestable {
   
   func test_NoData_CallsbackWithDataError() {
     let expect = expectation(description: "handler called")
-    self.request.send {(response, error) in
-      XCTAssertNil(response)
-      XCTAssertNotNil(error)
-      
-      XCTAssertEqual(error! as! ResponseError, ResponseError.noDataRecieved)
+    self.request.send {(result) in
+      XCTAssert(result.isErr())
+      XCTAssertEqual(result.intoErr()! as! ResponseError, .noDataRecieved)
       expect.fulfill()
     }
     
@@ -57,11 +53,9 @@ class GenericRequestTests: XCTestCase, RequestTestable {
   func test_MalformedURL_CallsbackWithRequestError() {
     let expect = expectation(description: "handler called")
     self.request = MockRequest(endpoint: "<~>", session: self.session)
-    self.request.send {(response, error) in
-      XCTAssertNil(response)
-      XCTAssertNotNil(error)
-      
-      XCTAssertEqual(error! as! RequestError, RequestError.failedToGenerate)
+    self.request.send {(result) in
+      XCTAssert(result.isErr())
+      XCTAssertEqual(result.intoErr()! as! RequestError, .failedToGenerate)
       expect.fulfill()
     }
     
@@ -72,11 +66,9 @@ class GenericRequestTests: XCTestCase, RequestTestable {
     let expect = expectation(description: "handler called")
     let mockError = NSError(domain: "mock", code: 0, userInfo: nil)
     self.session.nextError = mockError
-    self.request.send {(response, error) in
-      XCTAssertNil(response)
-      XCTAssertNotNil(error)
-      
-      XCTAssertEqual(error! as! RequestError, RequestError.failedToSend(err: mockError))
+    self.request.send {(result) in
+      XCTAssert(result.isErr())
+      XCTAssertEqual(result.intoErr()! as! RequestError, .failedToSend(err: mockError))
       expect.fulfill()
     }
     

--- a/HikeOregon/HikeOregonTests/Utilities/ResultTests.swift
+++ b/HikeOregon/HikeOregonTests/Utilities/ResultTests.swift
@@ -1,0 +1,115 @@
+//
+//  ResultTests.swift
+//  HikeOregon
+//
+//  Created by Daniel Seitz on 2/28/17.
+//  Copyright © 2017 hikeoregon. All rights reserved.
+//
+
+import XCTest
+@testable import HikeOregon
+
+class ResultTests: XCTestCase {
+  
+  func test_Result_isOk() {
+    let x: Result<Int, String> = .ok(1)
+    XCTAssert(x.isOk())
+    
+    let y: Result<Int, String> = .err("Oops")
+    XCTAssertFalse(y.isOk())
+  }
+  
+  func test_Result_isErr() {
+    let x: Result<Int, String> = .ok(1)
+    XCTAssertFalse(x.isErr())
+    
+    let y: Result<Int, String> = .err("Oops")
+    XCTAssert(y.isErr())
+  }
+  
+  func test_Result_makeOk() {
+    let x: Result<Int, String> = .ok(1)
+    XCTAssertEqual(x.intoOk(), 1)
+    
+    let y: Result<Int, String> = .err("Oops")
+    XCTAssertNil(y.intoOk())
+  }
+  
+  func test_Result_makeErr() {
+    let x: Result<Int, String> = .ok(1)
+    XCTAssertNil(x.intoErr())
+    
+    let y: Result<Int, String> = .err("Oops")
+    XCTAssertEqual(y.intoErr(), "Oops")
+  }
+  
+  func test_Result_map() {
+    let x: Result<Int, String> = .ok(5)
+    XCTAssertEqual(x.map({ $0 * 2 }).intoOk(), 10)
+  }
+  
+  func test_Result_mapErr() {
+    let x: Result<Int, String> = .err("Hello")
+    XCTAssertEqual(x.mapErr({ "\($0), World" }).intoErr(), "Hello, World")
+  }
+  
+  func test_Result_and() {
+    let x1: Result<Int, String> = .ok(2)
+    let y1: Result<String, String> = .err("late error")
+    XCTAssertEqual(x1.and(y1).intoErr(), "late error")
+    
+    let x2: Result<Int, String> = .err("early error")
+    let y2: Result<String, String> = .ok("foo")
+    XCTAssertEqual(x2.and(y2).intoErr(), "early error")
+    
+    let x3: Result<Int, String> = .err("early error")
+    let y3: Result<String, String> = .err("late error")
+    XCTAssertEqual(x3.and(y3).intoErr(), "early error")
+    
+    let x4: Result<Int, String> = .ok(2)
+    let y4: Result<String, String> = .ok("different result type")
+    XCTAssertEqual(x4.and(y4).intoOk(), "different result type")
+  }
+  
+  func test_Result_andThen() {
+    let sq: (Int) -> Result<Int, Int> = { .ok($0 * $0) }
+    let err: (Int) -> Result<Int, Int> = { .err($0) }
+    let ok: Result<Int, Int> = .ok(2)
+    let error: Result<Int, Int> = .err(3)
+    
+    XCTAssertEqual(ok.andThen(sq).andThen(sq).intoOk(), 16)
+    XCTAssertEqual(ok.andThen(sq).andThen(err).intoErr(), 4)
+    XCTAssertEqual(ok.andThen(err).andThen(sq).intoErr(), 2)
+    XCTAssertEqual(error.andThen(sq).andThen(sq).intoErr(), 3)
+  }
+  
+  func test_Result_or() {
+    let x1: Result<Int, String> = .ok(2)
+    let y1: Result<Int, String> = .err("late error")
+    XCTAssertEqual(x1.or(y1).intoOk(), 2)
+    
+    let x2: Result<Int, String> = .err("early error")
+    let y2: Result<Int, String> = .ok(2)
+    XCTAssertEqual(x2.or(y2).intoOk(), 2)
+    
+    let x3: Result<Int, String> = .err("early error")
+    let y3: Result<Int, String> = .err("late error")
+    XCTAssertEqual(x3.or(y3).intoErr(), "late error")
+    
+    let x4: Result<Int, String> = .ok(2)
+    let y4: Result<Int, String> = .ok(100)
+    XCTAssertEqual(x4.or(y4).intoOk(), 2)
+  }
+  
+  func test_Result_orElse() {
+    let sq: (Int) -> Result<Int, Int> = { .ok($0 * $0) }
+    let err: (Int) -> Result<Int, Int> = { .err($0) }
+    let ok: Result<Int, Int> = .ok(2)
+    let error: Result<Int, Int> = .err(3)
+    
+    XCTAssertEqual(ok.orElse(sq).orElse(sq).intoOk(), 2)
+    XCTAssertEqual(ok.orElse(err).orElse(sq).intoOk(), 2)
+    XCTAssertEqual(error.orElse(sq).orElse(err).intoOk(), 9)
+    XCTAssertEqual(error.orElse(err).orElse(err).intoErr(), 3)
+  }
+}


### PR DESCRIPTION
Provides bit safer static guarantees about the result of a request. Right now it's just being used for network requests, but is generic enough to be used for any failable operations. This gives compile time checking in the `send` function that a valid completion handler will be called (with either a `response` object or an `error` object). Right now this isn't much of an issue since the function isn't that complicated, but if more control paths pop up in the future this guarantees that either a success or fail is passed back to the caller. 

It also statically forces the caller to handle both cases, success or failure, which is good practice. Even if handling an error is just to ignore it, it's best to explicitly ignore it so in the future it can be known as a conscious decision. 